### PR TITLE
log: Add Record.Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `RPCGRPCResponseMetadata`
 - Add `ErrorType` attribute helper function to the `go.opentelmetry.io/otel/semconv/v1.34.0` package. (#6962)
 
+- `log.Record.Clone()` method that returns a copy of the record with no shared state. (#6986)
+
 ### Changed
 
 - Change `AssertEqual` in `go.opentelemetry.io/otel/log/logtest` to accept `TestingT` in order to support benchmarks and fuzz tests. (#6908)

--- a/log/record.go
+++ b/log/record.go
@@ -142,3 +142,11 @@ func (r *Record) AddAttributes(attrs ...KeyValue) {
 func (r *Record) AttributesLen() int {
 	return r.nFront + len(r.back)
 }
+
+// Clone returns a copy of the record with no shared state. 
+// The original record and the clone can both be modified without interfering with each other.
+func (r *Record) Clone() Record {
+    res := *r
+    res.back = slices.Clone(r.back)
+    return res
+}

--- a/log/record.go
+++ b/log/record.go
@@ -143,10 +143,10 @@ func (r *Record) AttributesLen() int {
 	return r.nFront + len(r.back)
 }
 
-// Clone returns a copy of the record with no shared state. 
+// Clone returns a copy of the record with no shared state.
 // The original record and the clone can both be modified without interfering with each other.
 func (r *Record) Clone() Record {
-    res := *r
-    res.back = slices.Clone(r.back)
-    return res
+	res := *r
+	res.back = slices.Clone(r.back)
+	return res
 }

--- a/log/record_test.go
+++ b/log/record_test.go
@@ -160,3 +160,51 @@ func TestRecordAllocationLimits(t *testing.T) {
 	// Convince the linter these values are used.
 	_, _, _, _, _, _ = tStamp, sev, text, body, n, attr
 }
+
+func TestRecordClone(t *testing.T) {
+	now0 := time.Now()
+	sev0 := log.SeverityInfo
+	text0 := "text"
+	val0 := log.BoolValue(true)
+	attr0 := log.Bool("0", true)
+
+	r0 := log.Record{}
+	r0.SetTimestamp(now0)
+	r0.SetObservedTimestamp(now0)
+	r0.SetSeverity(sev0)
+	r0.SetSeverityText(text0)
+	r0.SetBody(val0)
+	r0.AddAttributes(attr0)
+
+	now1 := now0.Add(time.Second)
+	sev1 := log.SeverityDebug
+	text1 := "string"
+	val1 := log.IntValue(1)
+	attr1 := log.Int64("1", 2)
+
+	r1 := r0.Clone()
+	r1.SetTimestamp(now1)
+	r1.SetObservedTimestamp(now1)
+	r1.SetSeverity(sev1)
+	r1.SetSeverityText(text1)
+	r1.SetBody(val1)
+	r1.AddAttributes(attr1)
+
+	assert.Equal(t, now0, r0.Timestamp())
+	assert.Equal(t, now0, r0.ObservedTimestamp())
+	assert.Equal(t, sev0, r0.Severity())
+	assert.Equal(t, text0, r0.SeverityText())
+	assert.True(t, val0.Equal(r0.Body()))
+	r0.WalkAttributes(func(kv log.KeyValue) bool {
+		return assert.Truef(t, kv.Equal(attr0), "%v != %v", kv, attr0)
+	})
+
+	assert.Equal(t, now1, r1.Timestamp())
+	assert.Equal(t, now1, r1.ObservedTimestamp())
+	assert.Equal(t, sev1, r1.Severity())
+	assert.Equal(t, text1, r1.SeverityText())
+	assert.True(t, val1.Equal(r1.Body()))
+	r1.WalkAttributes(func(kv log.KeyValue) bool {
+		return assert.Truef(t, kv.Equal(attr1), "%v != %v", kv, attr1)
+	})
+}


### PR DESCRIPTION
Fixes #6986

This PR adds a `Clone()` method to the `log.Record` type.

The `Clone` method returns a copy of the record with no shared state, allowing both the original and the clone to be modified independently. Specifically, the `back` slice is cloned using `slices.Clone` to prevent shared references between the original and cloned records.

This functionality mirrors the existing `sdk/log.Record.Clone()` behavior and includes a corresponding unit test (`TestRecordClone`) to ensure correctness.
